### PR TITLE
Remove redundant "emacs" from package description

### DIFF
--- a/neotree.el
+++ b/neotree.el
@@ -1,4 +1,4 @@
-;;; neotree.el --- A emacs tree plugin like NerdTree for Vim
+;;; neotree.el --- A tree plugin like NerdTree for Vim
 
 ;; Copyright (C) 2014 jaypei
 


### PR DESCRIPTION
From within Emacs it will be clear that this is meant for use in Emacs. :-)
