### PR TITLE
Add option to open neotree at project root

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # emacs-neotree #
 
-A emacs tree plugin like NerdTree for Vim.
+A Emacs tree plugin like NerdTree for Vim.
 
 `Develop` [![Build Status](https://travis-ci.org/jaypei/emacs-neotree.svg?branch=dev)](https://travis-ci.org/jaypei/emacs-neotree)
 `Master` [![Build Status](https://travis-ci.org/jaypei/emacs-neotree.svg?branch=master)](https://travis-ci.org/jaypei/emacs-neotree)
@@ -12,14 +12,16 @@ A emacs tree plugin like NerdTree for Vim.
 
 ## Installation ##
 
-### melpa
+### Melpa
 
 You can install the plugin using the packages on [melpa](http://melpa.milkbox.net/).
 
 Make sure you have something like the following in your Emacs startup file (`~/.emacs.d/init.el`, or `~/.emacs`):
 
+```elisp
     (add-to-list 'package-archives
                  '("melpa" . "http://melpa.milkbox.net/packages/"))
+```
 
 To make that take effect, either evaluate that elisp expression or restart Emacs.
 
@@ -27,8 +29,27 @@ Then use `M-x package-list-packages`, select `neotree` from
 the list by pressing `i`, then press `x` to execute the changes. At
 that point, the package will be installed.
 
+### Useful tips
 
-### source
+If you use the `find-file-in-project` (ffip) library, you can open `neotree` at your directory root by
+adding this code to your `.emacs.d`:
+
+```elisp
+(defun neotree-project-dir ()
+  "Open dirtree using the git root."
+  (interactive)
+  (let ((project-dir (ffip-project-root))
+        (file-name (buffer-file-name)))
+    (if project-dir
+        (progn
+          (neotree-dir project-dir)
+          (neotree-find file-name))
+      (message "Could not find git project root."))))
+
+(define-key map (kbd "C-c C-p") 'neotree-project-dir)
+```
+
+### Source
 
 Clone project:
 ```sh
@@ -57,4 +78,3 @@ Open (toggle) NeoTree:
 
 * [EmacsWiki](http://www.emacswiki.org/emacs/NeoTree)
 * [中文版 NeoTree](http://www.emacswiki.org/emacs-zh/NeoTree_%E4%B8%AD%E6%96%87wiki)
-


### PR DESCRIPTION
I have made a function to open the tree widget right at the project root given by the find-file-in-project package.

I'm not really sure how Melpa handles dependencies, but I think adding the (require 'find-file-in-project) is enough.
