### PR TITLE
Add less verbose keybindings for neotree-mode-map

### DIFF
--- a/neotree.el
+++ b/neotree.el
@@ -81,6 +81,10 @@ By default all filest starting with dot '.' including . and ..")
   :type 'integer
   :group 'neotree)
 
+(defcustom neo-keymap-style-consise nil
+  "*If non-nil, set concise keybindings for neotree-mode-map."
+  :type 'boolean
+  :group 'neotree)
 
 ;;
 ;; Faces
@@ -178,11 +182,19 @@ The car of the pair will store fullpath, and cdr will store line number.")
     (define-key map (kbd "C-x 1")   'neotree-empty-fn)
     (define-key map (kbd "C-x 2")   'neotree-empty-fn)
     (define-key map (kbd "C-x 3")   'neotree-empty-fn)
-    (define-key map (kbd "C-c C-c") 'neotree-change-root)
     (define-key map (kbd "C-c C-f") 'find-file-other-window)
-    (define-key map (kbd "C-c C-n") 'neotree-create-node)
-    (define-key map (kbd "C-c C-d") 'neotree-delete-node)
-    (define-key map (kbd "C-c C-r") 'neotree-rename-node)
+    (define-key map (kbd "C-c C-c") 'neotree-change-root)
+    (if neo-keymap-style-consise
+        (progn
+          (define-key map (kbd "c") 'neotree-create-node)
+          (define-key map (kbd "+") 'neotree-create-node)
+          (define-key map (kbd "d") 'neotree-delete-node)
+          (define-key map (kbd "r") 'neotree-rename-node)
+          (define-key map (kbd "e") 'neotree-enter))
+      (progn
+        (define-key map (kbd "C-c C-n") 'neotree-create-node)
+        (define-key map (kbd "C-c C-d") 'neotree-delete-node)
+        (define-key map (kbd "C-c C-r") 'neotree-rename-node)))
     map)
   "Keymap for `neotree-mode'.")
 


### PR DESCRIPTION
I think that `C-c C-r`, `C-c C-d` and `C-c C-c` are too verbose, and are not really necessary. 

I have added single key bindings for such commands.
