### PR TITLE
Add popwin support through around advices

### DIFF
--- a/neotree.el
+++ b/neotree.el
@@ -428,6 +428,45 @@ it will create the neotree window and return it."
    (neo-buffer--lock-width))
   ad-return-value)
 
+(eval-after-load 'popwin
+  '(progn
+     (defadvice popwin:popup-buffer
+         (around neotree/popwin-popup-buffer activate)
+       (let ((neobuffer (get-buffer neo-buffer-name))
+             (neopersist neo-persist-show))
+         (when neobuffer
+           (setq neo-persist-show nil)
+           (with-current-buffer (neo-global--get-buffer)
+             (neo-buffer--unlock-width)))
+         ad-do-it
+         (when neobuffer
+           (setq neo-persist-show neopersist)
+           (with-current-buffer (neo-global--get-buffer)
+             (neo-buffer--lock-width))
+           ;; set neotree global window and buffer to the new ones
+           ;; created by popwin
+           (setq neo-global--buffer (get-buffer neo-buffer-name))
+           (setq neo-global--window (get-buffer-window
+                                     neo-global--buffer)))))
+
+     (defadvice popwin:close-popup-window
+         (around neotree/popwin-close-popup-window activate)
+       (let ((neobuffer (get-buffer neo-buffer-name))
+             (neopersist neo-persist-show))
+         (when neobuffer
+           (setq neo-persist-show nil)
+           (with-current-buffer (neo-global--get-buffer)
+             (neo-buffer--unlock-width)))
+         ad-do-it
+         (when neobuffer
+           (setq neo-persist-show neopersist)
+           (with-current-buffer (neo-global--get-buffer)
+             (neo-buffer--lock-width))
+           ;; set neotree global window and buffer to the new ones
+           ;; created by popwin
+           (setq neo-global--buffer (get-buffer neo-buffer-name))
+           (setq neo-global--window (get-buffer-window
+                                     neo-global--buffer)))))))
 
 ;;
 ;; Util methods


### PR DESCRIPTION
Hi Pei,

This PR adds popwin support.

I needed it for my Emacs distribution because it uses heavily [guide-key](https://github.com/kai2nenobu/guide-key), by extension the fix should work for all popups. This solution has been tested in a non trivial Emacs configuration and works nicely (see [spacemacs](https://github.com/syl20bnr/spacemacs)).

I tried the hack with the hooks (https://github.com/jaypei/emacs-neotree/issues/50) but it has limitation like not being able to perform action when the popup window actually closes.

Cheers,
syl20bnr
