### PR TITLE
Fix bad indentation of files

### DIFF
--- a/neotree.el
+++ b/neotree.el
@@ -806,7 +806,7 @@ PATH is value."
     (setq btn-start-pos (point))
     (neo-buffer--insert-with-face (if expanded "-" "+")
                           'neo-expand-btn-face)
-    (neo-buffer--insert-with-face (concat " " node-short-name "/")
+    (neo-buffer--insert-with-face (concat node-short-name "/")
                           'neo-dir-link-face)
     (setq btn-end-pos (point))
     (make-button btn-start-pos
@@ -821,7 +821,6 @@ PATH is value."
 (defun neo-buffer--insert-file-entry (node depth)
   (let ((node-short-name (neo-path--file-short-name node)))
     (insert-char ?\s (* (- depth 1) 2)) ; indent
-    (insert-char ?\s 2)
     (insert-button node-short-name
                    'action '(lambda (x) (neotree-enter))
                    'follow-link t


### PR DESCRIPTION
Hi Pei,

I'm sure that this additional indentation has been added on purpose but it breaks readability.

See the screenshots below, the first one shows the files has if they were in the extensions directory which is wrong.
Now I think this additional indentation has been added because when there are only files in a directory they appear on the same indent level as the parent directory, but this is OK and consistent with the display of the root and its content.

Before (left) / After (right):

![capture d ecran 2014-12-28 a 18 39 11](https://cloud.githubusercontent.com/assets/1243537/5565319/4a7a7a08-8ec1-11e4-9ca9-8fae5fbb0655.png) ![capture d ecran 2014-12-28 a 18 39 54](https://cloud.githubusercontent.com/assets/1243537/5565320/510e1212-8ec1-11e4-9457-066cb6946b9d.png)

Cheers,
syl20bnr