### PR TITLE
Remove newline when neo-banner-message neo-show-updir-line are nil

### DIFF
--- a/neotree.el
+++ b/neotree.el
@@ -875,7 +875,8 @@ PATH is value."
     (neo-buffer--newline-and-begin)))
 
 (defun neo-buffer--insert-root-entry (node)
-  (neo-buffer--newline-and-begin)
+  (when (or neo-banner-message neo-show-updir-line)
+    (neo-buffer--newline-and-begin))
   (when neo-show-updir-line
     (insert-button ".."
                    'action '(lambda (x) (neotree-change-root))


### PR DESCRIPTION
Hi Pei,

This PR removes the newline if one set both `neo-banner-message` and `neo-show-updir-line` to `nil`.

(left: before / right: after)

![capture d ecran 2014-12-31 a 16 58 47](https://cloud.githubusercontent.com/assets/1243537/5590823/ed1fe492-910e-11e4-8a64-28a765456885.png) ![capture d ecran 2014-12-31 a 17 00 27](https://cloud.githubusercontent.com/assets/1243537/5590828/f1606702-910e-11e4-9603-4332534aaab3.png)

Cheers,
syl20bnr