### PR TITLE
Correct customisation group

### DIFF
--- a/neotree.el
+++ b/neotree.el
@@ -141,11 +141,10 @@ buffer-local wherever it is set."
 ;; Customization
 ;;
 
-(defgroup neotree-options nil
+(defgroup neotree nil
   "Options for neotree."
   :prefix "neo-"
-  :group 'neotree
-  :link '(info-link "(neotree)Configuration"))
+  :group 'files)
 
 (defcustom neo-create-file-auto-open nil
   "*If non-nil, the file will auto open when created."


### PR DESCRIPTION
 * Replaces empty `neotree-options` group with the `neotree` group
 * Puts the group under the correct category of Files
 * Removes the empty info link