### PR TITLE
Strip a common prefix from shortened path

### DIFF
--- a/neotree.el
+++ b/neotree.el
@@ -35,8 +35,6 @@
 
 ;;; Code:
 
-(eval-when-compile (require 'subr-x))
-
 ;;
 ;; Constants
 ;;
@@ -724,7 +722,13 @@ This procedure does not work when CONDP is the `null' function."
   "Remove whitespace at the end of S."
   (if (string-match "[ \t\n\r]+\\'" s)
       (replace-match "" t t s)
-    s))
+   s))
+
+(defun neo-str--remove-prefix (prefix s)
+ "Remove PREFIX from string S."
+ (if (string-prefix-p prefix s)
+  (substring s (length prefix))
+  s))
 
 (defun neo-str--trim (s)
   "Remove whitespace at the beginning and end of S."
@@ -742,7 +746,7 @@ This procedure does not work when CONDP is the `null' function."
 This is needed for paths, which are to long for the window to display
 completely.  The function cuts of the first part of the path to remain
 the last folder (the current one)."
- (let ((path (string-remove-prefix neo-strip-path-prefix path)))
+ (let ((path (neo-str--remove-prefix neo-strip-path-prefix path)))
   (if (> (string-width path) length)
    (concat "<" (substring path (- (- length 1))))
    path)))

--- a/neotree.el
+++ b/neotree.el
@@ -35,6 +35,8 @@
 
 ;;; Code:
 
+(eval-when-compile (require 'subr-x))
+
 ;;
 ;; Constants
 ;;
@@ -169,6 +171,11 @@ buffer-local wherever it is set."
 (defcustom neo-show-updir-line t
   "*If non-nil, show the updir line (..)."
   :type 'boolean
+  :group 'neotree)
+
+(defcustom neo-strip-path-prefix (getenv "HOME")
+  "Remove this common prefix from paths when shortening them for display."
+  :type 'string
   :group 'neotree)
 
 (defcustom neo-theme 'classic
@@ -731,13 +738,14 @@ This procedure does not work when CONDP is the `null' function."
         r-path)))
 
 (defun neo-path--shorten (path length)
-  "Shorten a given PATH to a specified LENGTH.
+ "Shorten a given PATH to a specified LENGTH.
 This is needed for paths, which are to long for the window to display
 completely.  The function cuts of the first part of the path to remain
 the last folder (the current one)."
+ (let ((path (string-remove-prefix neo-strip-path-prefix path)))
   (if (> (string-width path) length)
-      (concat "<" (substring path (- (- length 1))))
-    path))
+   (concat "<" (substring path (- (- length 1))))
+   path)))
 
 (defun neo-path--insert-chroot-button (label path face)
   (insert-button


### PR DESCRIPTION
It's kind of irritating to show the part of the shortened path that is
common to all directories. Would be nice to be able to easily strip a
common prefix for instance your $HOME or some custom directory in which
you manage all your source code.

I used remove-string-prefix from subr-x (Emacs 24.4 onward). Not sure what version(s) neotree is targeting and if it would be preferable to use s.el or re-implement a prefix stripping function.