### PR TITLE
make neotree work with evil-mode

### DIFF
--- a/neotree.el
+++ b/neotree.el
@@ -1819,7 +1819,9 @@ automatically."
   (if neo-smart-open
       (neotree-find)
     (neo-global--open))
-  (neo-global--select-window))
+  (neo-global--select-window)
+  (when evil-mode
+    (evil-local-mode 0)))
 
 ;;;###autoload
 (defun neotree-hide ()


### PR DESCRIPTION
I was having some issues running this with `evil-mode` turned on globally. Basically, `evil-mode` was taking over the keyboard bindings. This fix disables evil-mode locally in the buffer so that you can continue to use `evil-mode` in other buffers except the neotree one.