### PR TITLE
Improve setting neo-dir

### DIFF
--- a/neotree.el
+++ b/neotree.el
@@ -43,7 +43,9 @@
   "Name of the buffer where neotree shows directory contents.")
 
 (defconst neo-dir
-  (expand-file-name (file-name-directory (locate-library "neotree"))))
+  (expand-file-name (if load-file-name
+                        (file-name-directory load-file-name)
+                      default-directory)))
 
 (defconst neo-header-height 5)
 


### PR DESCRIPTION
'emacs -Q -l neotree.el' is failed with original code because
(locate-library "neotree") returns nil in such case.