### PR TITLE
Added autoload cookies to neotree.el

### DIFF
--- a/neotree.el
+++ b/neotree.el
@@ -593,6 +593,7 @@ The car of the pair will store fullpath, and cdr will store line number.")
 ;; Global methods
 ;;
 
+;;;###autoload
 (defun neo-global--window-exists-p ()
   "Return non-nil if neotree window exists."
   (and (not (null (window-buffer neo-global--window)))
@@ -671,6 +672,7 @@ If INIT-P is non-nil and global NeoTree buffer not exists, then create it."
         (neo-global--open-dir (neo-path--get-working-dir))
       (neo-global--get-window t))))
 
+;;;###autoload
 (defun neo-global--open-dir (path)
   "Show the NeoTree window, and change root to PATH."
   (neo-global--get-window t)


### PR DESCRIPTION
Added autoload cookies to neotree.el to make it a bit easier for users to create alternate commands to open a neotreee window.

Specifically added ;;;###autoload in front of
 neo-global--window-exists-p and  neo-global--open-dir

This allows me elsewhere to create command neotree-show-hide which

+ closes the neotree window if it is open
+ calls neotree-show if the neotree window does not exist
+ when called with C-U, prompts the user for a director and opens neotree on that directory

