### PR TITLE
Set custom root name to project name in projectile

### DIFF
--- a/neotree.el
+++ b/neotree.el
@@ -1203,14 +1203,25 @@ PATH is value."
       (insert " (up a dir)")
       (set-text-properties start (point) '(face neo-header-face)))
     (neo-buffer--newline-and-begin))
-  (neo-buffer--node-list-set nil node)
-  (cond
-   ((eq neo-cwd-line-style 'button)
-    (neo-path--insert-header-buttonized node))
-   (t
-    (neo-buffer--insert-with-face (neo-path--shorten node (window-body-width))
-                                  'neo-root-dir-face)))
-  (neo-buffer--newline-and-begin))
+
+  (let ((project-name-or-node node)
+        (project-root nil))
+
+    (if (and (fboundp 'projectile-project-root)
+             (projectile-project-p))
+        (setq project-name-or-node
+              (concat "Project: "
+                      (file-name-nondirectory (directory-file-name (projectile-project-root))))))
+
+    (neo-buffer--node-list-set nil project-name-or-node)
+
+    (cond
+     ((eq neo-cwd-line-style 'button)
+      (neo-path--insert-header-buttonized project-name-or-node))
+     (t
+      (neo-buffer--insert-with-face (neo-path--shorten project-name-or-node (window-body-width))
+                                    'neo-root-dir-face)))
+    (neo-buffer--newline-and-begin)))
 
 (defun neo-buffer--insert-dir-entry (node depth expanded)
   (let ((node-short-name (neo-path--file-short-name node)))


### PR DESCRIPTION
Inside project root header look: 'Project: my-project'

This works unless the project name is too long, What do you think?

Cheers!
Thank for you work.
