### PR TITLE
Confirm overwrite at renaming

### DIFF
--- a/neotree.el
+++ b/neotree.el
@@ -1414,7 +1414,7 @@ If there is no button in current line, then return DEFAULT."
       (if buffer
           (with-current-buffer buffer
             (set-visited-file-name to-path nil t)))
-      (rename-file current-path to-path)
+      (rename-file current-path to-path 1)
       (neo-buffer--refresh t)
       (message "Rename successful."))))
 


### PR DESCRIPTION
Original code raises error if new name file is already existed.
This is related to #145.