### PR TITLE
Fix for older Emacs

### DIFF
--- a/neotree.el
+++ b/neotree.el
@@ -1244,6 +1244,7 @@ PATH is value."
     (neo-buffer--newline-and-begin)))
 
 (defun neo-vc-for-node (node)
+  (require 'vc)
   (let* ((backend (vc-responsible-backend node))
          (vc-state (when backend (vc-state node backend))))
     (cons (cdr (assoc vc-state neo-vc-state-char-alist))


### PR DESCRIPTION
vc-responsible-backend is not an autoload function on Emacs 24.5 or lower
versions. While it is an autoloaded function on Emacs 25 or higher versions.

This is related to #153.