### PR TITLE
fix `vc-responsible-backend` throwing when a leaf node was not tracked by a VCS

### DIFF
--- a/neotree.el
+++ b/neotree.el
@@ -1244,7 +1244,8 @@ PATH is value."
     (neo-buffer--newline-and-begin)))
 
 (defun neo-vc-for-node (node)
-  (let* ((backend (vc-responsible-backend node))
+  (let* ((backend (ignore-errors
+                    (vc-responsible-backend node)))
          (vc-state (when backend (vc-state node backend))))
     (cons (cdr (assoc vc-state neo-vc-state-char-alist))
           (cl-case vc-state


### PR DESCRIPTION
otherwise the cycle stops when the error is thrown and the whole file list is not populated