### PR TITLE
Support for multiple frames

### DIFF
--- a/neotree.el
+++ b/neotree.el
@@ -39,8 +39,11 @@
 ;; Constants
 ;;
 
-(defconst neo-buffer-name " *NeoTree*"
-  "Name of the buffer where neotree shows directory contents.")
+(defun neo-buffer-name ()
+  "Name of the buffer where neotree shows directory contents."
+  (if (projectile-project-p)
+      (format " *NeoTree <%s>*" (projectile-project-name))
+    (" *NeoTree*")))
 
 (defconst neo-dir
   (expand-file-name (if load-file-name
@@ -659,7 +662,7 @@ _ALIST is ignored."
   "Return the global neotree buffer if it exists.
 If INIT-P is non-nil and global NeoTree buffer not exists, then create it."
   (unless (equal (buffer-name neo-global--buffer)
-                 neo-buffer-name)
+                 (neo-buffer-name))
     (setf neo-global--buffer nil))
   (when (and init-p
              (null neo-global--buffer))
@@ -752,7 +755,7 @@ The description of ARG is in `neotree-enter'."
 
 (defun neo-global--attach ()
   "Attach the global neotree buffer"
-  (setq neo-global--buffer (get-buffer neo-buffer-name))
+  (setq neo-global--buffer (get-buffer (neo-buffer-name)))
   (setq neo-global--window (get-buffer-window
                             neo-global--buffer))
   (neo-global--with-buffer
@@ -1196,7 +1199,7 @@ PATH is value."
 (defun neo-buffer--create ()
   "Create and switch to NeoTree buffer."
   (switch-to-buffer
-   (generate-new-buffer-name neo-buffer-name))
+   (generate-new-buffer-name (neo-buffer-name)))
   (neotree-mode)
   ;; disable linum-mode
   (when (and (boundp 'linum-mode)


### PR DESCRIPTION
A couple of days ago I did this little hack as an experiment to see if I could have emacs-neotree support having a neotree buffer open for for each frame. So far it seems to work, but I don't know neotree well enough to say that it doesn't break any features.

Currently the hack solves my specific use-case of having a single neotree buffer for each frame -- I usually open a frame for each projectile project I'm working on.

If you think this is a good idea I'd be happy to spend a little time cleaning this up so it can be merged. The code right now is only a proof of concept to support multiple frames so we have a basis for discussion 😊 I was thinking to change it so that users can register a `neo-buffer-name-generator` function and then provide one for projectile as that seems to be a popular package to integrate with.
