### PR TITLE
Use graphic themes only when it's available/usable

### DIFF
--- a/neotree.el
+++ b/neotree.el
@@ -1089,7 +1089,7 @@ Optional NODE-NAME is used for the `icons' theme"
                            (neo-buffer--insert-with-face
                             n 'neo-expand-btn-face))))
     (cond
-     ((and window-system (equal neo-theme 'classic))
+     ((and (display-graphic-p) (equal neo-theme 'classic))
       (or (and (equal name 'open)  (funcall n-insert-image "open"))
           (and (equal name 'close) (funcall n-insert-image "close"))
           (and (equal name 'leaf)  (funcall n-insert-image "leaf"))))
@@ -1100,7 +1100,7 @@ Optional NODE-NAME is used for the `icons' theme"
       (or (and (equal name 'open)  (funcall n-insert-symbol "▾ "))
           (and (equal name 'close) (funcall n-insert-symbol "▸ "))
           (and (equal name 'leaf)  (funcall n-insert-symbol "  "))))
-     ((equal neo-theme 'icons)
+     ((and (display-graphic-p) (equal neo-theme 'icons))
       (unless (require 'all-the-icons nil 'noerror)
         (error "Package `all-the-icons' isn't installed"))
       (setq-local tab-width 1)


### PR DESCRIPTION
This helps when you start emacs with `--daemon` and use GUI and tty
simultaneously. Fix #194

* Use `display-graphic-p` instead of `window-system` which is deprecated for
  predicate use

The only caveat is if you open neotree in GUI and switch to same window in
terminal you won't get icons. Workaround is to toggle `neotree` in tty to switch
back to `+-` default theme.