### PR TITLE
fix create recursive directories

### DIFF
--- a/neotree.el
+++ b/neotree.el
@@ -1870,7 +1870,7 @@ If the current node is the first node then the last node is selected."
       (when (and (not is-file)
                  (funcall neo-confirm-create-directory (format "Do you want to create directory %S?"
                                                                filename)))
-        (mkdir filename)
+        (mkdir filename t)
         (neo-buffer--save-cursor-pos filename)
         (neo-buffer--refresh nil)))))
 


### PR DESCRIPTION
Currently ```neotree-create-node``` function create only one directory, this change adds possibility to create subdirectories and parent directories in the same call.

ie.
`newdir/subdir1/subdir2/subdir3/`
