### PR TITLE
Improve compatibility with remote files

### DIFF
--- a/neotree.el
+++ b/neotree.el
@@ -1536,9 +1536,12 @@ If RECURSIVE-P is non nil, find files will recursively."
         (when (neo-path--file-equal-p iter-curr-dir neo-buffer--start-node)
           (setq file-node-find-p t)
           (throw 'return nil))
-        (when (neo-path--file-equal-p iter-curr-dir "/")
-          (setq file-node-find-p nil)
-          (throw 'return nil))))
+        (let ((niter-curr-dir (file-remote-p iter-curr-dir 'localname)))
+          (unless niter-curr-dir
+            (setq niter-curr-dir iter-curr-dir))
+          (when (neo-path--file-equal-p niter-curr-dir "/")
+            (setq file-node-find-p nil)
+            (throw 'return nil)))))
     (when file-node-find-p
       (dolist (p file-node-list)
         (neo-buffer--set-expand p t))


### PR DESCRIPTION
I'm trying to use NeoTree with TRAMP (via Spacemacs) but found that a call to `(neotree-find (projectile-project-root))` from within TRAMP is causing Emacs to hang.

After some debugging, it looks like the loop inside `neo-buffer--select-file-node` from within TRAMP environment would never return, as `iter-curr-dir` will never be `/` since NeoTree is dealing with remote file, the root path will looks like `/ssh:10.0.1.2:/`. 

In this PR, I called `file-remote-p` to return local name for remote path, which fixed the issue.