### PR TITLE
Indents when navigating line up and down

### DIFF
--- a/neotree.el
+++ b/neotree.el
@@ -1752,13 +1752,17 @@ NeoTree buffer is BUFFER."
   "Move next line in NeoTree buffer.
 Optional COUNT argument, moves COUNT lines down."
   (interactive "p")
-  (neo-buffer--forward-line (or count 1)))
+  (neo-buffer--forward-line (or count 1))
+  (when neo-auto-indent-point
+    (neo-point-auto-indent)))
 
 (defun neotree-previous-line (&optional count)
   "Move previous line in NeoTree buffer.
 Optional COUNT argument, moves COUNT lines up."
   (interactive "p")
-  (neo-buffer--forward-line (- (or count 1))))
+  (neo-buffer--forward-line (- (or count 1)))
+  (when neo-auto-indent-point
+    (neo-point-auto-indent)))
 
 ;;;###autoload
 (defun neotree-find (&optional path default-path)


### PR DESCRIPTION
I'd really like to have this behaviour in neotree. If you want to keep the old behaviour intact I can also create new variable that controlls this behaviour and enable it in my emacs config. What do you think?