### PR TITLE
Fix the neo-buffer--post-move default-directory

### DIFF
--- a/neotree.el
+++ b/neotree.el
@@ -1509,7 +1509,7 @@ If SAVE-POS-P is non-nil, it will be auto save current line number."
        (setq default-directory (neo-path--updir btn-full-path)))
     :dir-fn
     '(lambda (path _)
-       (setq default-directory path)))))
+       (setq default-directory (file-name-as-directory path))))))
 
 (defun neo-buffer--get-button-current-line ()
   "Return the first button in current line."


### PR DESCRIPTION
Right now, the `dir-fn` sets the `default-directory` without the trailing `/`, which confuses functions like `counsel-find-file`.

This issue is referenced here(other project): https://github.com/syl20bnr/spacemacs/issues/9199