### PR TITLE
Allow icon mode in terminal

### DIFF
--- a/neotree.el
+++ b/neotree.el
@@ -1236,7 +1236,7 @@ Optional NODE-NAME is used for the `icons' theme"
       (or (and (equal name 'open)  (funcall n-insert-symbol "▾ "))
           (and (equal name 'close) (funcall n-insert-symbol "▸ "))
           (and (equal name 'leaf)  (funcall n-insert-symbol "  "))))
-     ((and (display-graphic-p) (equal neo-theme 'icons))
+     ((equal neo-theme 'icons)
       (unless (require 'all-the-icons nil 'noerror)
         (error "Package `all-the-icons' isn't installed"))
       (setq-local tab-width 1)


### PR DESCRIPTION
Terminals can have all-the-icons and/or nerdfonts activated so they can display icons. 

Let's allow the user to activate this behaviour in case that they really want.

This is an screenshot of my terminal displaying the icons:

![2017-09-22-223613_452x497_scrot](https://user-images.githubusercontent.com/837104/30765224-7848186c-9fe6-11e7-807e-4064df3f1f9c.png)

To make the test I've changed this in my configuration:

```
  (use-package all-the-icons :ensure t)
  (advice-add 'display-graphic-p :override (lambda () t))
  (setq neo-theme  'icons)
```