### PR TITLE
Protect against `neo-global--window` being set, but invalid

### DIFF
--- a/neotree.el
+++ b/neotree.el
@@ -707,7 +707,8 @@ The car of the pair will store fullpath, and cdr will store line number.")
 
 (defun neo-global--window-exists-p ()
   "Return non-nil if neotree window exists."
-  (and (not (null (window-buffer neo-global--window)))
+  (and (window-valid-p neo-global--window)
+       (not (null (window-buffer neo-global--window)))
        (eql (window-buffer neo-global--window) (neo-global--get-buffer))))
 
 (defun neo-global--select-window ()


### PR DESCRIPTION
`window-buffer` requires it's argument to satisfy the `window-valid-p`
predicate -- but if the predicate fails, `window-buffer` errors, rather than
returning nil. This means that if the window displaying neotree becomes invalid,
trying to toggle neotree can stop working entirely.

Lifting the `window-valid-p` predicate into `neo-global--window-exists-p`
protects against this without altering the possible return types of the function.