### PR TITLE
Change root with up-dir shortcuts. Fixes jaypei#290

### DIFF
--- a/neotree.el
+++ b/neotree.el
@@ -1818,7 +1818,8 @@ the directory instead of showing the directory contents."
 
 FULL-PATH is the path of the directory.
 ARG is ignored."
-  (if neo-click-changes-root
+  (if (or neo-click-changes-root
+          (equal full-path (neo-path--updir neo-buffer--start-node)))
       (neotree-change-root)
     (progn
       (let ((new-state (neo-buffer--toggle-expand full-path)))


### PR DESCRIPTION
Currently the shortcut keys (RET, SPC) do not trigger a change root to the parent directory on the ".." node. To trigger it, you have to move your cursor to the ".." button.

This fix makes the shortcut keys trigger a change root if the path is equal to the parent directory path.