### PR TITLE
fix neotree-show path when in symbol links dir with projectile

### DIFF
--- a/neotree.el
+++ b/neotree.el
@@ -2133,7 +2133,8 @@ automatically."
         (progn
           (when (and (fboundp 'projectile-project-p)
                      (projectile-project-p)
-                     (fboundp 'projectile-project-root))
+                     (fboundp 'projectile-project-root)
+                     (setq path (file-truename path)))
             (neotree-dir (projectile-project-root)))
           (neotree-find path))
       (neo-global--open))


### PR DESCRIPTION
when in symbol links dir with projectile

projectile use `file-truename` to detect the `projectile-project-root`

so, fix the path with truename to expand the path cerrectly