### PR TITLE
Smart open project w/ built-in project lib

### DIFF
--- a/neotree.el
+++ b/neotree.el
@@ -2131,10 +2131,18 @@ automatically."
         (path (buffer-file-name)))  ;; save current window and buffer
     (if neo-smart-open
         (progn
-          (when (and (fboundp 'projectile-project-p)
-                     (projectile-project-p)
-                     (fboundp 'projectile-project-root))
-            (neotree-dir (projectile-project-root)))
+          (cond ((and (fboundp 'projectile-project-p)
+                      (projectile-project-p)
+                      (fboundp 'projectile-project-root))
+                 (neotree-dir (projectile-project-root)))
+                (t
+                 (neotree-dir
+                  (project-root
+                   (or (project--find-in-directory default-directory)
+                       (progn
+                         (message "Using `%s' as a transient project root"
+                                  default-directory)
+                         (cons 'transient default-directory)))))))
           (neotree-find path))
       (neo-global--open))
     (neo-global--select-window)


### PR DESCRIPTION
If projectile is not present, make `neo-smart-open` default to Emacs'
built-in project library, which is capable of finding, e.g., the root of
a Git repository higher up in the directory tree.

Would fix https://emacs.stackexchange.com/questions/29499/how-to-toggle-neotree-in-the-project-directory