### PR TITLE
New theme using `nerd-icons`

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Only in Neotree Buffer:
 ## Configurations
 
 ### Theme config
-NeoTree provides following themes: *classic*(default) *ascii* *arrow* *icons* *nerd*. 
+NeoTree provides following themes: *classic*(default) *ascii* *arrow* *icons* *nerd* *nerd-icons*.
 Theme can be configed by setting **neo-theme**. For example, use *icons* for window 
 system and *arrow* terminal.
 
@@ -84,7 +84,13 @@ system and *arrow* terminal.
 (setq neo-theme (if (display-graphic-p) 'icons 'arrow))
 ```
 
-**Note**: For users who want to use the `icons` theme. Pls make sure you have installed the
+**Note**:
+
+For user who want to use the `nerd-icons` theme. Pls make sure you have installed the
+[nerd-icons](https://github.com/rainstormstudio/nerd-icons.el) package and its
+[fonts](https://github.com/rainstormstudio/nerd-icons.el#installing-fonts).
+
+For users who want to use the `icons` theme. Pls make sure you have installed the
 [all-the-icons](https://github.com/domtronn/all-the-icons.el) package and its
 [fonts](https://github.com/domtronn/all-the-icons.el/tree/master/fonts).
 

--- a/neotree.el
+++ b/neotree.el
@@ -1274,9 +1274,7 @@ Optional NODE-NAME is used for the `icons' theme"
                                (nerd-icons-octicon "nf-oct-chevron_right" :v-adjust 0.1 :face neo-expand-btn-face)
                                (nerd-icons-icon-for-dir (directory-file-name node-name) :v-adjust 0.1))))
           (and (equal name 'leaf)
-               (insert (format "\t\t\t%s "
-                               ;;(nerd-icons-octicon "nf-oct-dot_fill")
-                               (nerd-icons-icon-for-file node-name :v-adjust 0.1))))))
+               (insert (format "\t\t\t%s " (nerd-icons-icon-for-file node-name :v-adjust 0.1))))))
 
      ((and (display-graphic-p) (equal neo-theme 'icons))
       (unless (require 'all-the-icons nil 'noerror)

--- a/neotree.el
+++ b/neotree.el
@@ -1260,6 +1260,24 @@ Optional NODE-NAME is used for the `icons' theme"
       (or (and (equal name 'open)  (funcall n-insert-symbol "▾ "))
           (and (equal name 'close) (funcall n-insert-symbol "▸ "))
           (and (equal name 'leaf)  (funcall n-insert-symbol "  "))))
+
+     ((equal neo-theme 'nerd-icons)
+      (unless (require 'nerd-icons nil 'noerror)
+        (error "Package `nerd-icons' isn't installed"))
+      (setq-local tab-width 1)
+      (or (and (equal name 'open)
+               (insert (format "%s\t%s "
+                               (nerd-icons-octicon "nf-oct-chevron_down" :v-adjust 0.1 :face neo-expand-btn-face)
+                               (nerd-icons-icon-for-dir (directory-file-name node-name) :v-adjust 0.1))))
+          (and (equal name 'close)
+               (insert (format "%s\t%s "
+                               (nerd-icons-octicon "nf-oct-chevron_right" :v-adjust 0.1 :face neo-expand-btn-face)
+                               (nerd-icons-icon-for-dir (directory-file-name node-name) :v-adjust 0.1))))
+          (and (equal name 'leaf)
+               (insert (format "\t\t\t%s "
+                               ;;(nerd-icons-octicon "nf-oct-dot_fill")
+                               (nerd-icons-icon-for-file node-name :v-adjust 0.1))))))
+
      ((and (display-graphic-p) (equal neo-theme 'icons))
       (unless (require 'all-the-icons nil 'noerror)
         (error "Package `all-the-icons' isn't installed"))

--- a/neotree.el
+++ b/neotree.el
@@ -209,12 +209,16 @@ window."
 `ascii' is the simplest style, it will use +/- to display the fold state,
 it suitable for terminal.
 `arrow' use unicode arrow.
-`nerd' use the nerdtree indentation mode and arrow."
+`nerd' use the nerdtree indentation mode and arrow.
+`nerd-icons' use `nerd-icons', requires that to be installed.
+`icons' use `all-the-icons', requires that to be installed.
+"
   :group 'neotree
   :type '(choice (const classic)
                  (const ascii)
                  (const arrow)
                  (const icons)
+                 (const nerd-icons)
                  (const nerd)))
 
 (defcustom neo-mode-line-type 'neotree


### PR DESCRIPTION
Hi, this adds a new theme using [nerd-icons](https://github.com/rainstormstudio/nerd-icons.el).

This means the icons will work in both GUI and console, since `nerd-icons` supports that, here's a screenshot, using the `spacemacs-light` theme:

![image](https://github.com/jaypei/emacs-neotree/assets/66709197/c6609a0a-6c0d-4b75-ba93-d231cc984b9a)
