### PR TITLE
Fix error url for emacs wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,4 +95,4 @@ system and *arrow* terminal.
 
 EmacsWiki:
 [En](http://www.emacswiki.org/emacs/NeoTree)
-[中文版](http://www.emacswiki.org/emacs-zh/NeoTree_%E4%B8%AD%E6%96%87wiki)
+[中文版](http://www.emacswiki.org/emacs/NeoTree_%E4%B8%AD%E6%96%87wiki)


### PR DESCRIPTION
The previous URL of emacs wiki `中文版` cannot be accessed
